### PR TITLE
Rename command classes

### DIFF
--- a/src/Console/Commands/Build.php
+++ b/src/Console/Commands/Build.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Http\Request;
 
 
-class BuildSite extends Command
+class Build extends Command
 {
   /**
    * The name and signature of the console command.

--- a/src/Console/Commands/Serve.php
+++ b/src/Console/Commands/Serve.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Symfony\Component\Process\Process;
 
-class ServeSite extends Command
+class Serve extends Command
 {
   protected $signature = 'scabbard:serve {--once}';
 

--- a/src/Console/Commands/Watch.php
+++ b/src/Console/Commands/Watch.php
@@ -6,7 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use Scabbard\Console\Commands\Concerns\WatchesFiles;
 
-class WatchSite extends Command
+class Watch extends Command
 {
   use WatchesFiles;
 

--- a/src/ScabbardServiceProvider.php
+++ b/src/ScabbardServiceProvider.php
@@ -3,9 +3,9 @@
 namespace Scabbard;
 
 use Illuminate\Support\ServiceProvider;
-use Scabbard\Console\Commands\BuildSite;
-use Scabbard\Console\Commands\WatchSite;
-use Scabbard\Console\Commands\ServeSite;
+use Scabbard\Console\Commands\Build;
+use Scabbard\Console\Commands\Watch;
+use Scabbard\Console\Commands\Serve;
 
 class ScabbardServiceProvider extends ServiceProvider
 {
@@ -19,9 +19,9 @@ class ScabbardServiceProvider extends ServiceProvider
 
         // Register Artisan commands
         $this->commands([
-            BuildSite::class,
-            WatchSite::class,
-            ServeSite::class,
+            Build::class,
+            Watch::class,
+            Serve::class,
         ]);
     }
 

--- a/tests/Unit/BuildTest.php
+++ b/tests/Unit/BuildTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Scabbard\Tests\TestCase;
 
-class BuildSiteTest extends TestCase
+class BuildTest extends TestCase
 {
     public function test_build_site_command_generates_static_files(): void
     {

--- a/tests/Unit/ServeTest.php
+++ b/tests/Unit/ServeTest.php
@@ -7,21 +7,22 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Scabbard\Tests\TestCase;
 
-class WatchSiteTest extends TestCase
+class ServeTest extends TestCase
 {
-    public function test_site_watch_triggers_build(): void
+    public function test_site_serve_runs_watch_and_serves(): void
     {
         $tempOutputDir = base_path('tests/tmp_output');
 
         File::deleteDirectory($tempOutputDir);
 
         Config::set('scabbard.copy_dirs', []);
-        Config::set('scabbard.views', ['watch.html' => 'home']);
+        Config::set('scabbard.views', ['serve.html' => 'home']);
         Config::set('scabbard.output_path', $tempOutputDir);
+        Config::set('scabbard.serve_port', 5678);
 
-        Artisan::call('scabbard:watch', ['--once' => true]);
+        Artisan::call('scabbard:serve', ['--once' => true]);
 
-        $this->assertTrue(File::exists("{$tempOutputDir}/watch.html"));
+        $this->assertTrue(File::exists("{$tempOutputDir}/serve.html"));
 
         File::deleteDirectory($tempOutputDir);
     }

--- a/tests/Unit/WatchTest.php
+++ b/tests/Unit/WatchTest.php
@@ -7,22 +7,21 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Scabbard\Tests\TestCase;
 
-class ServeSiteTest extends TestCase
+class WatchTest extends TestCase
 {
-    public function test_site_serve_runs_watch_and_serves(): void
+    public function test_site_watch_triggers_build(): void
     {
         $tempOutputDir = base_path('tests/tmp_output');
 
         File::deleteDirectory($tempOutputDir);
 
         Config::set('scabbard.copy_dirs', []);
-        Config::set('scabbard.views', ['serve.html' => 'home']);
+        Config::set('scabbard.views', ['watch.html' => 'home']);
         Config::set('scabbard.output_path', $tempOutputDir);
-        Config::set('scabbard.serve_port', 5678);
 
-        Artisan::call('scabbard:serve', ['--once' => true]);
+        Artisan::call('scabbard:watch', ['--once' => true]);
 
-        $this->assertTrue(File::exists("{$tempOutputDir}/serve.html"));
+        $this->assertTrue(File::exists("{$tempOutputDir}/watch.html"));
 
         File::deleteDirectory($tempOutputDir);
     }


### PR DESCRIPTION
## Summary
- rename command classes to `Build`, `Watch`, and `Serve`
- update service provider and test class names

There was no `AGENTS.md` file in the repository.

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687347c23738832fa2ea3596bc9f36c3