### PR TITLE
Setup php-cs-fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /vendor/
 .phpunit.result.cache
 composer.lock
+
+.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,12 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/src')
+    ->in(__DIR__.'/tests');
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+    ])
+    ->setIndent('  ')
+    ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,13 @@
         }
     ],
     "minimum-stability": "stable",
-    "require": {},
-		"require-dev": {
+    "require-dev": {
 			"orchestra/testbench": "^8.0 || ^9.0",
-			"phpunit/phpunit": "^10.0"
+			"phpunit/phpunit": "^10.0",
+        "friendsofphp/php-cs-fixer": "^3.82"
+		},
+		"scripts": {
+			"cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php"
 		},
 		"extra": {
 			"laravel": {

--- a/src/Console/Commands/Build.php
+++ b/src/Console/Commands/Build.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Http\Request;
 
-
 class Build extends Command
 {
   /**


### PR DESCRIPTION
## Summary
- add php-cs-fixer as a dev dependency
- configure php-cs-fixer and composer script
- ignore php-cs-fixer cache file

## Testing
- `composer install`
- `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --allow-risky=yes`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687349febb38832f806974c0d3b04dae