### PR TITLE
Add PHPStan static analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ php artisan scabbard:watch
 
 This is just an alias for `php artisan scabbard:build --watch`
 
+## Static Analysis
+
+This project uses [PHPStan](https://phpstan.org/) for static code analysis. Run:
+
+```
+composer phpstan
+```
+
+to analyze the codebase.
+
 ## Notes
 
 - Works with Laravel 10 and above.

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,13 @@
     "require-dev": {
 			"orchestra/testbench": "^8.0 || ^9.0",
 			"phpunit/phpunit": "^10.0",
-        "friendsofphp/php-cs-fixer": "^3.82"
+        "friendsofphp/php-cs-fixer": "^3.82",
+        "phpstan/phpstan": "^2.1"
 		},
-		"scripts": {
-			"cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php"
-		},
+                "scripts": {
+                        "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",
+                        "phpstan": "phpstan analyse --configuration=phpstan.neon.dist --memory-limit=512M"
+                },
 		"extra": {
 			"laravel": {
 				"providers": [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,55 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to an undefined method Illuminate\\Contracts\\View\\Factory\|Illuminate\\Contracts\\View\\View\:\:render\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Console/Commands/Build.php
+
+		-
+			message: '#^Call to static method call\(\) on an unknown class Artisan\.$#'
+			identifier: class.notFound
+			count: 1
+			path: src/Console/Commands/Build.php
+
+		-
+			message: '#^Method Scabbard\\Console\\Commands\\Build\:\:buildSite\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Console/Commands/Build.php
+
+		-
+			message: '#^Method Scabbard\\Console\\Commands\\Build\:\:deleteAndCreate\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Console/Commands/Build.php
+
+		-
+			message: '#^Method Scabbard\\Console\\Commands\\Build\:\:handle\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Console/Commands/Build.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(dir \- The directory path\.\)\: Unexpected token "\-", expected variable at offset 94 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Console/Commands/Build.php
+
+		-
+			message: '#^Parameter \#2 \$contents of static method Illuminate\\Support\\Facades\\File\:\:put\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Console/Commands/Build.php
+
+		-
+			message: '#^Method Scabbard\\Console\\Commands\\Serve\:\:handle\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Console/Commands/Serve.php
+
+		-
+			message: '#^Method Scabbard\\Console\\Commands\\Watch\:\:handle\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Console/Commands/Watch.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,9 @@
+includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 8
+    paths:
+        - src
+        - tests


### PR DESCRIPTION
## Summary
- set up PHPStan with baseline
- add a Composer script to run PHPStan
- document static analysis in the README

No AGENTS.md was found in the repository.

## Testing
- `vendor/bin/phpstan analyse --configuration=phpstan.neon.dist --memory-limit=512M`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6873519272ac832f86826b1d225543a2