### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run PHP CS Fixer
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php
+
+      - name: Run PHPStan
+        run: composer phpstan
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --testdox


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running PHP CS Fixer, PHPStan and PHPUnit

No AGENTS.md found in the repository.

## Testing
- `composer install --no-interaction --prefer-dist --no-progress`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php`
- `composer phpstan`
- `vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_6873583b8770832f8010bc9f90b91a8b