### PR TITLE
Add AGENTS with project guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+This repository uses PSR-12 style with two space indentation. Run `composer cs:fix` before committing.
+
+Run static analysis with `composer phpstan`. Run tests with `vendor/bin/phpunit`.
+
+PRs should include a summary of changes and note that tests and static analysis pass.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` to document coding style, testing commands, and PR expectations

The repository did not previously include an `AGENTS.md` file.

## Testing
- `composer phpstan`
- `vendor/bin/phpunit --stop-on-failure`
- `composer cs:fix`

------
https://chatgpt.com/codex/tasks/task_e_68735849112c832fbd72d3d8d32ddf5c