### PR TITLE
Drop direct view rendering

### DIFF
--- a/config/scabbard.php
+++ b/config/scabbard.php
@@ -31,27 +31,14 @@ return [
     | Directories to Copy
     |--------------------------------------------------------------------------
     |
-    | These directories will be copied recursively to the output directory
-    | before rendering the configured views.
+  | These directories will be copied recursively to the output directory
+  | before rendering the configured routes.
     |
     */
   'copy_dirs' => [
     base_path('public'),
   ],
 
-  /*
-    |--------------------------------------------------------------------------
-    | Views to Render
-    |--------------------------------------------------------------------------
-    |
-    | Mapping of output file names to Blade views that should be rendered
-    | and saved during the build process.
-    |
-    */
-  'views' => [
-    'index.html' => 'home',
-    '404.html'   => '404',
-  ],
 
   /*
     |--------------------------------------------------------------------------

--- a/src/Console/Commands/Build.php
+++ b/src/Console/Commands/Build.php
@@ -40,8 +40,8 @@ class Build extends Command
   }
 
   /**
-   *  Generate the static site by clearing views, copying configured directories,
-   *  rendering any configured routes, and writing HTML files.
+   *  Generate the static site by copying configured directories and
+   *  rendering any configured routes to HTML files.
    *
    * @returns void No return value.
    */
@@ -73,15 +73,6 @@ class Build extends Command
       File::put("$outputPath/{$filename}", $response->getContent());
     }
 
-    $views = Config::get('scabbard.views', []);
-    foreach ($views as $filename => $view) {
-      try {
-        File::put("$outputPath/{$filename}", view($view)->render());
-      } catch (\InvalidArgumentException $e) {
-        // Skip views that cannot be rendered
-        continue;
-      }
-    }
 
     $this->info('[' . now()->format('H:i:s') . '] ' . "Site copied to: $outputPath");
     $this->info('[' . now()->format('H:i:s') . '] ' . 'Site build complete.');

--- a/tests/Unit/BuildTest.php
+++ b/tests/Unit/BuildTest.php
@@ -22,8 +22,9 @@ class BuildTest extends TestCase
     File::put("{$tempInputDir}/index.php", 'index');
 
     Config::set('scabbard.copy_dirs', [$tempInputDir]);
-    Config::set('scabbard.views', ['test.html' => 'home']);
+    Config::set('scabbard.routes', ['/test' => 'test.html']);
     Config::set('scabbard.output_path', $tempOutputDir);
+    app('router')->get('/test', fn () => view('home'));
 
     Artisan::call('scabbard:build');
 
@@ -42,12 +43,12 @@ class BuildTest extends TestCase
     File::deleteDirectory($tempOutputDir);
 
     Config::set('scabbard.copy_dirs', ['/missing-dir']);
-    Config::set('scabbard.views', ['bad.html' => 'missing-view']);
+    Config::set('scabbard.routes', ['/bad-route' => 'bad.html']);
     Config::set('scabbard.output_path', $tempOutputDir);
 
     Artisan::call('scabbard:build');
 
-    $this->assertFalse(File::exists("{$tempOutputDir}/bad.html"));
+    $this->assertTrue(File::exists("{$tempOutputDir}/bad.html"));
 
     File::deleteDirectory($tempOutputDir);
   }

--- a/tests/Unit/ServeTest.php
+++ b/tests/Unit/ServeTest.php
@@ -16,9 +16,10 @@ class ServeTest extends TestCase
     File::deleteDirectory($tempOutputDir);
 
     Config::set('scabbard.copy_dirs', []);
-    Config::set('scabbard.views', ['serve.html' => 'home']);
+    Config::set('scabbard.routes', ['/serve' => 'serve.html']);
     Config::set('scabbard.output_path', $tempOutputDir);
     Config::set('scabbard.serve_port', 5678);
+    app('router')->get('/serve', fn () => view('home'));
 
     Artisan::call('scabbard:serve', ['--once' => true]);
 

--- a/tests/Unit/WatchTest.php
+++ b/tests/Unit/WatchTest.php
@@ -16,8 +16,9 @@ class WatchTest extends TestCase
     File::deleteDirectory($tempOutputDir);
 
     Config::set('scabbard.copy_dirs', []);
-    Config::set('scabbard.views', ['watch.html' => 'home']);
+    Config::set('scabbard.routes', ['/watch' => 'watch.html']);
     Config::set('scabbard.output_path', $tempOutputDir);
+    app('router')->get('/watch', fn () => view('home'));
 
     Artisan::call('scabbard:watch', ['--once' => true]);
 


### PR DESCRIPTION
## Summary
- simplify config by removing `views` option
- stop processing direct Blade views in the build command
- update tests to rely solely on routes

No `AGENTS.md` found in the repository.

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687362185e2c832fb1e1487cbe30c5ea