### PR TITLE
Refactor timestamp prefix

### DIFF
--- a/src/Console/Commands/Build.php
+++ b/src/Console/Commands/Build.php
@@ -7,10 +7,12 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Http\Request;
 use Scabbard\Console\Commands\Concerns\WatchesFiles;
+use Scabbard\Console\Commands\Concerns\HasTimestampPrefix;
 
 class Build extends Command
 {
   use WatchesFiles;
+  use HasTimestampPrefix;
   /**
    * The name and signature of the console command.
    *
@@ -33,7 +35,7 @@ class Build extends Command
   public function handle()
   {
     if ($this->option('watch')) {
-      $this->info('[' . now()->format('H:i:s') . '] ' . 'Watching for changes...');
+      $this->info($this->timestampPrefix() . 'Watching for changes...');
 
       $lastHash = null;
 
@@ -44,12 +46,12 @@ class Build extends Command
 
         if ($lastHash !== $currentHash) {
           $lastHash = $currentHash;
-          $this->info('[' . now()->format('H:i:s') . '] ' . 'Rebuilding...');
+          $this->info($this->timestampPrefix() . 'Rebuilding...');
           $this->buildSite();
         }
 
         $this->trap(SIGINT, function () {
-          $this->info('[' . now()->format('H:i:s') . '] ' . 'Watcher interrupted. Exiting.');
+          $this->info($this->timestampPrefix() . 'Watcher interrupted. Exiting.');
           exit;
         });
 
@@ -95,8 +97,8 @@ class Build extends Command
     }
 
 
-    $this->info('[' . now()->format('H:i:s') . '] ' . "Site copied to: $outputPath");
-    $this->info('[' . now()->format('H:i:s') . '] ' . 'Site build complete.');
+    $this->info($this->timestampPrefix() . "Site copied to: $outputPath");
+    $this->info($this->timestampPrefix() . 'Site build complete.');
   }
 
   /**

--- a/src/Console/Commands/Concerns/HasTimestampPrefix.php
+++ b/src/Console/Commands/Concerns/HasTimestampPrefix.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Scabbard\Console\Commands\Concerns;
+
+trait HasTimestampPrefix
+{
+  protected function timestampPrefix(): string
+  {
+    return '[' . now()->format('H:i:s') . '] ';
+  }
+}

--- a/src/Console/Commands/Serve.php
+++ b/src/Console/Commands/Serve.php
@@ -5,10 +5,13 @@ namespace Scabbard\Console\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
+use Scabbard\Console\Commands\Concerns\HasTimestampPrefix;
 use Symfony\Component\Process\Process;
 
 class Serve extends Command
 {
+  use HasTimestampPrefix;
+
   protected $signature = 'scabbard:serve {--once}';
 
   protected $description = 'Watch the site and serve the built output';
@@ -29,15 +32,14 @@ class Serve extends Command
     ]);
     $process->start();
 
-    $this->info('[' . now()->format('H:i:s') . '] ' . 'Serving site on http://127.0.0.1:' . $port);
+    $this->info($this->timestampPrefix() . 'Serving site on http://127.0.0.1:' . $port);
 
-    
     Artisan::call('scabbard:build', ['--watch' => true], $this->output);
 
-    $this->info('[' . now()->format('H:i:s') . '] ' . 'Serving site on http://127.0.0.1:' . $port);
+    $this->info($this->timestampPrefix() . 'Serving site on http://127.0.0.1:' . $port);
 
     $process->stop();
 
-    $this->info('[' . now()->format('H:i:s') . '] ' . 'Server stopped.');
+    $this->info($this->timestampPrefix() . 'Server stopped.');
   }
 }


### PR DESCRIPTION
## Summary
- centralize repeated timestamp prefix in a new `HasTimestampPrefix` trait
- use the new trait in `Build` and `Serve` commands

No `AGENTS.md` was found in this project.

## Testing
- `composer cs:fix`
- `timeout 10 vendor/bin/phpunit` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68736f42ee70832f9ab001e3d0d501fe