### PR TITLE
Handle missing directory indexes

### DIFF
--- a/router.php
+++ b/router.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *  Router script used by `scabbard:serve` to provide a custom 404 page.
  *
@@ -9,18 +10,32 @@
 $uri = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
 $path = $_SERVER['DOCUMENT_ROOT'] . $uri;
 
+function serveNotFound(): void
+{
+  http_response_code(404);
+  $notFoundPath = $_SERVER['DOCUMENT_ROOT'] . '/404.html';
+
+  if (file_exists($notFoundPath)) {
+    readfile($notFoundPath);
+  } else {
+    echo '<h1>404 Not Found</h1><p>The page you are looking for does not exist.</p>';
+  }
+}
+
 // Let the built-in server handle existing files but not directories.
 if ($uri !== '/' && is_file($path)) {
-    return false;
+  return false;
 }
 
 // Serve index.html for directory-based routes like /blog/my-post
 if ($uri !== '/' && is_dir($path)) {
-    $indexFile = rtrim($path, '/\\') . '/index.html';
-    if (file_exists($indexFile)) {
-        readfile($indexFile);
-        return true;
-    }
+  $indexFile = rtrim($path, '/\\') . '/index.html';
+  if (file_exists($indexFile)) {
+    readfile($indexFile);
+    return true;
+  }
+  serveNotFound();
+  return true;
 }
 
 // PHP does not automatically serve index.html for the root path
@@ -31,12 +46,4 @@ if ($uri === '/' || $uri === '') {
 
 
 // Serve custom 404
-http_response_code(404);
-$notFoundPath = $_SERVER['DOCUMENT_ROOT'] . '/404.html';
-
-if (file_exists($notFoundPath)) {
-    readfile($notFoundPath);
-} else {
-    echo "<h1>404 Not Found</h1><p>The page you are looking for does not exist.</p>";
-}
-
+serveNotFound();


### PR DESCRIPTION
## Summary
- ensure directories without an `index.html` return the 404 page
- note absence of `AGENTS.md`

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --stop-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687377834ee0832f810b79ba4faa52fd