### PR TITLE
Fix phpstan issues

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,11 @@ namespace Scabbard\Tests;
 
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
+/**
+ * Base test case for package tests.
+ *
+ * @property \Illuminate\Foundation\Application $app
+ */
 abstract class TestCase extends BaseTestCase
 {
   protected function getPackageProviders($app)

--- a/tests/Unit/ServeTest.php
+++ b/tests/Unit/ServeTest.php
@@ -14,9 +14,10 @@ class ServeTest extends TestCase
   {
     parent::setUp();
 
-    $kernel = $this->app->make(\Illuminate\Contracts\Console\Kernel::class);
+    /** @var \Illuminate\Foundation\Console\Kernel $kernel */
+    $kernel = $this->app->make(\Illuminate\Foundation\Console\Kernel::class);
     $kernel->registerCommand(new class extends \Scabbard\Console\Commands\Build {
-      public function handle()
+      public function handle(): void
       {
         $this->buildSite();
       }


### PR DESCRIPTION
## Summary
- address phpstan complaints in tests
- annotate test base case with application property
- register test command using correct Kernel type

## Testing
- `composer run phpstan`
- `vendor/bin/phpunit --filter BuildTest --testdox`
- `vendor/bin/phpunit --filter WatchTest --testdox`
- `timeout 10s vendor/bin/phpunit --filter ServeTest --testdox` *(fails: EXIT 124)*

------
https://chatgpt.com/codex/tasks/task_e_6873f9c490f8832f9c13eebd9ab17d6c