### PR TITLE
Fix tests to prevent infinite runs

### DIFF
--- a/tests/Unit/WatchTest.php
+++ b/tests/Unit/WatchTest.php
@@ -2,9 +2,9 @@
 
 namespace Scabbard\Tests\Unit;
 
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Output\NullOutput;
 use Scabbard\Tests\TestCase;
 
 class WatchTest extends TestCase
@@ -20,7 +20,15 @@ class WatchTest extends TestCase
     Config::set('scabbard.output_path', $tempOutputDir);
     app('router')->get('/watch', fn () => view('home'));
 
-    Artisan::call('scabbard:build');
+    $command = new class () extends \Scabbard\Console\Commands\Build {
+      public function handle(): void
+      {
+        $this->buildSite();
+      }
+    };
+    $command->setLaravel($this->app);
+
+    $command->run(new \Symfony\Component\Console\Input\ArrayInput([]), new NullOutput());
 
     $this->assertTrue(File::exists("{$tempOutputDir}/watch.html"));
 


### PR DESCRIPTION
## Summary
- ensure ServeTest and WatchTest run without launching infinite loops
- run scabbard:serve and scabbard:build with stub commands

AGENTS.md not found in this repository.

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml --testdox`
- `composer phpstan`

------
https://chatgpt.com/codex/tasks/task_e_6874128e5fcc832f8fec3f4a8b1bfcbc