### PR TITLE
Add Laravel requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ composer require dempe/scabbard --dev
 php artisan vendor:publish --tag=scabbard-config
 ```
 
+Scabbard requires a Laravel 10 or 11 installation. Composer will install the
+necessary `illuminate/*` packages that match your framework version.
+
 ## Configuration
 
 Configs are in `config/scabbard.php`.

--- a/composer.json
+++ b/composer.json
@@ -1,40 +1,47 @@
 {
-    "name": "dempe/scabbard",
-    "description": "Artisan commands for generating a static site based on Blade templates",
-    "type": "library",
-    "license": "MIT",
-    "autoload": {
-        "psr-4": {
-            "Scabbard\\": "src/"
-        }
-    },
-		"autoload-dev": {
-			"psr-4": {
-				"Scabbard\\Tests\\": "tests/"
-			}
-		},
-    "authors": [
-        {
-            "name": "Christopher Dempewolf",
-            "email": "chris@chrisdempewolf.com"
-        }
-    ],
-    "minimum-stability": "stable",
-    "require-dev": {
-			"orchestra/testbench": "^8.0 || ^9.0",
-			"phpunit/phpunit": "^10.0",
-        "friendsofphp/php-cs-fixer": "^3.82",
-        "phpstan/phpstan": "^2.1"
-		},
-                "scripts": {
-                        "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",
-                        "phpstan": "phpstan analyse --configuration=phpstan.neon.dist --memory-limit=512M"
-                },
-		"extra": {
-			"laravel": {
-				"providers": [
-					"Scabbard\\ScabbardServiceProvider"
-				]
-			}
-		}
+  "name": "dempe/scabbard",
+  "description": "Artisan commands for generating a static site based on Blade templates",
+  "type": "library",
+  "license": "MIT",
+  "autoload": {
+    "psr-4": {
+      "Scabbard\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Scabbard\\Tests\\": "tests/"
+    }
+  },
+  "authors": [
+    {
+      "name": "Christopher Dempewolf",
+      "email": "chris@chrisdempewolf.com"
+    }
+  ],
+  "minimum-stability": "stable",
+  "require": {
+    "php": "^8.1",
+    "illuminate/console": "^10.0 || ^11.0",
+    "illuminate/filesystem": "^10.0 || ^11.0",
+    "illuminate/view": "^10.0 || ^11.0",
+    "illuminate/support": "^10.0 || ^11.0"
+  },
+  "require-dev": {
+    "orchestra/testbench": "^8.0 || ^9.0",
+    "phpunit/phpunit": "^10.0",
+    "friendsofphp/php-cs-fixer": "^3.82",
+    "phpstan/phpstan": "^2.1"
+  },
+  "scripts": {
+    "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",
+    "phpstan": "phpstan analyse --configuration=phpstan.neon.dist --memory-limit=512M"
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Scabbard\\ScabbardServiceProvider"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- list illuminate components required to run within Laravel
- document Laravel version requirements

No `AGENTS.md` found in the repo.

## Testing
- `composer validate --no-check-all --strict`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68752fe7c824832f905f8f721ebb2c92