### PR TITLE
Add config check to commands

### DIFF
--- a/src/Console/Commands/Build.php
+++ b/src/Console/Commands/Build.php
@@ -34,6 +34,11 @@ class Build extends Command
    */
   public function handle()
   {
+    if (! file_exists(config_path('scabbard.php'))) {
+      $this->error('Scabbard config not found. Run: php artisan vendor:publish --tag=scabbard-config');
+      return Command::FAILURE;
+    }
+
     if ($this->option('watch')) {
       $this->info($this->timestampPrefix() . 'Watching for changes...');
 

--- a/src/Console/Commands/Serve.php
+++ b/src/Console/Commands/Serve.php
@@ -18,6 +18,11 @@ class Serve extends Command
 
   public function handle()
   {
+    if (! file_exists(config_path('scabbard.php'))) {
+      $this->error('Scabbard config not found. Run: php artisan vendor:publish --tag=scabbard-config');
+      return Command::FAILURE;
+    }
+
     $outputPath = Config::get('scabbard.output_path', base_path('output'));
     $port = Config::get('scabbard.serve_port', 8000);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,16 @@ abstract class TestCase extends BaseTestCase
     return [\Scabbard\ScabbardServiceProvider::class];
   }
 
+  protected function setUp(): void
+  {
+    parent::setUp();
+    $configFile = base_path('config/scabbard.php');
+    \Illuminate\Support\Facades\File::ensureDirectoryExists(dirname($configFile));
+    if (! file_exists($configFile)) {
+      file_put_contents($configFile, "<?php return [];\n");
+    }
+  }
+
   protected function getEnvironmentSetUp($app)
   {
     $app['config']->set('scabbard.output_path', __DIR__ . '/output');


### PR DESCRIPTION
## Summary
- check for `config/scabbard.php` in Build and Serve commands and show error when missing
- ensure tests create a dummy config file

AGENTS.md file was not found in the repository root.

## Testing
- `composer cs:fix`
- `composer phpstan`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68755758f1ec832fb7ac8cf8393de1bb