### PR TITLE
Refactor config check into trait

### DIFF
--- a/src/Console/Commands/Build.php
+++ b/src/Console/Commands/Build.php
@@ -8,11 +8,13 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Http\Request;
 use Scabbard\Console\Commands\Concerns\WatchesFiles;
 use Scabbard\Console\Commands\Concerns\HasTimestampPrefix;
+use Scabbard\Console\Commands\Concerns\RequiresScabbardConfig;
 
 class Build extends Command
 {
   use WatchesFiles;
   use HasTimestampPrefix;
+  use RequiresScabbardConfig;
   /**
    * The name and signature of the console command.
    *
@@ -34,8 +36,7 @@ class Build extends Command
    */
   public function handle()
   {
-    if (! file_exists(config_path('scabbard.php'))) {
-      $this->error('Scabbard config not found. Run: php artisan vendor:publish --tag=scabbard-config');
+    if (! $this->ensureScabbardConfigExists()) {
       return Command::FAILURE;
     }
 

--- a/src/Console/Commands/Concerns/RequiresScabbardConfig.php
+++ b/src/Console/Commands/Concerns/RequiresScabbardConfig.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Scabbard\Console\Commands\Concerns;
+
+trait RequiresScabbardConfig
+{
+  protected function ensureScabbardConfigExists(): bool
+  {
+    if (! file_exists(config_path('scabbard.php'))) {
+      $this->error('Scabbard config not found. Run: php artisan vendor:publish --tag=scabbard-config');
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/Console/Commands/Serve.php
+++ b/src/Console/Commands/Serve.php
@@ -6,11 +6,13 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Scabbard\Console\Commands\Concerns\HasTimestampPrefix;
+use Scabbard\Console\Commands\Concerns\RequiresScabbardConfig;
 use Symfony\Component\Process\Process;
 
 class Serve extends Command
 {
   use HasTimestampPrefix;
+  use RequiresScabbardConfig;
 
   protected $signature = 'scabbard:serve';
 
@@ -18,8 +20,7 @@ class Serve extends Command
 
   public function handle()
   {
-    if (! file_exists(config_path('scabbard.php'))) {
-      $this->error('Scabbard config not found. Run: php artisan vendor:publish --tag=scabbard-config');
+    if (! $this->ensureScabbardConfigExists()) {
       return Command::FAILURE;
     }
 


### PR DESCRIPTION
## Summary
- reuse config check across commands with a trait

There is no AGENTS.md in the repository.

## Testing
- `composer cs:fix`
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68755bd9c4ec832fa7006fd476b9ae7b