### PR TITLE
Fix router path for Serve command

### DIFF
--- a/src/Console/Commands/Serve.php
+++ b/src/Console/Commands/Serve.php
@@ -28,6 +28,10 @@ class Serve extends Command
     $port = Config::get('scabbard.serve_port', 8000);
 
     $router = base_path('router.php');
+
+    if (! file_exists($router)) {
+      $router = realpath(__DIR__ . '/../../../router.php');
+    }
     $process = new Process([
       'php',
       '-S',


### PR DESCRIPTION
## Summary
- search for router.php in project root first
- fall back to router.php shipped with the package

AGENTS.md was not found in this project.

## Testing
- `composer cs:fix`
- `composer phpstan`
- `vendor/bin/phpunit --colors=never`


------
https://chatgpt.com/codex/tasks/task_e_68755f33a8ac832f8c684dabe26afb31