### PR TITLE
Handle build failures when rendering routes

### DIFF
--- a/tests/Unit/BuildTest.php
+++ b/tests/Unit/BuildTest.php
@@ -5,6 +5,7 @@ namespace Scabbard\Tests\Unit;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
+use Illuminate\Console\Command;
 use Scabbard\Tests\TestCase;
 
 class BuildTest extends TestCase
@@ -46,9 +47,10 @@ class BuildTest extends TestCase
     Config::set('scabbard.routes', ['/bad-route' => 'bad.html']);
     Config::set('scabbard.output_path', $tempOutputDir);
 
-    Artisan::call('scabbard:build');
+    $result = Artisan::call('scabbard:build');
 
-    $this->assertTrue(File::exists("{$tempOutputDir}/bad.html"));
+    $this->assertSame(Command::FAILURE, $result);
+    $this->assertFalse(File::exists("{$tempOutputDir}/bad.html"));
 
     File::deleteDirectory($tempOutputDir);
   }


### PR DESCRIPTION
## Summary
- wrap `app()->handle(Request::create(...))` in try/catch
- fail the build when a route returns an error or throws
- return failure exit codes from the build command
- update the failing test to expect build failure

No `AGENTS.md` was found in the repository root.

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68756e195614832fac4c7c0e8ca157b4