### PR TITLE
Create directories for route outputs

### DIFF
--- a/src/Console/Commands/Build.php
+++ b/src/Console/Commands/Build.php
@@ -107,7 +107,9 @@ class Build extends Command
           continue;
         }
 
-        File::put("$outputPath/{$filename}", $response->getContent());
+        $filePath = $outputPath . DIRECTORY_SEPARATOR . ltrim($filename, DIRECTORY_SEPARATOR);
+        File::ensureDirectoryExists(dirname($filePath));
+        File::put($filePath, $response->getContent());
       } catch (\Throwable $e) {
         $this->error($this->timestampPrefix() . "Exception rendering {$uri}: " . $e->getMessage());
       }

--- a/tests/Unit/BuildTest.php
+++ b/tests/Unit/BuildTest.php
@@ -54,4 +54,27 @@ class BuildTest extends TestCase
 
     File::deleteDirectory($tempOutputDir);
   }
+
+  public function test_build_site_creates_directories_for_routes(): void
+  {
+    $tempInputDir = base_path('tests/tmp_public');
+    $tempOutputDir = base_path('tests/tmp_output');
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+
+    File::ensureDirectoryExists($tempInputDir);
+
+    Config::set('scabbard.copy_dirs', [$tempInputDir]);
+    Config::set('scabbard.routes', ['/athena' => 'athena/index.html']);
+    Config::set('scabbard.output_path', $tempOutputDir);
+    app('router')->get('/athena', fn () => view('home'));
+
+    Artisan::call('scabbard:build');
+
+    $this->assertTrue(File::exists("{$tempOutputDir}/athena/index.html"));
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+  }
 }


### PR DESCRIPTION
## Summary
- ensure output directories exist for each route path
- test that route directories are created automatically

No AGENTS.md found in repository root.

## Testing
- `composer cs:fix`
- `vendor/bin/phpunit --configuration phpunit.xml --color=always`


------
https://chatgpt.com/codex/tasks/task_e_687698f2dc3c832fb457592047876785