### PR TITLE
Implement dynamic route closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ These are directories that are copied wholesale into your configured output dire
 
 This is a mapping of routes (defined in your app's `routes/web.php`) to their filenames in your configured output directory.
 
+### Dynamic Routes
+
+Dynamic routes allow generating multiple pages from a single route pattern. Define `dynamic_routes` in your `scabbard.php` config with a mapping of output file patterns to a closure that returns the placeholder values. For example:
+
+```php
+'dynamic_routes' => [
+    '/posts/{slug}/index.html' => fn () => App\Models\Post::pluck('slug'),
+],
+```
+
+The closure should return an iterable of values. When building, each value replaces the `{slug}` placeholder to produce both the request URI and output file path.
+
 ### Server Port
 
 The port your server runs on (default `8000`).

--- a/config/scabbard.php
+++ b/config/scabbard.php
@@ -55,6 +55,22 @@ return [
 
   /*
     |--------------------------------------------------------------------------
+    | Dynamic Routes
+    |--------------------------------------------------------------------------
+    |
+    | Mapping of output paths containing placeholders to a closure that returns
+    | the values for those placeholders. The closure should return an iterable
+    | of values. When a single placeholder is used, scalar values are accepted.
+    | For multiple placeholders, return associative arrays keyed by placeholder
+    | name.
+    |
+    */
+  'dynamic_routes' => [
+    // '/posts/{slug}/index.html' => fn () => App\Models\Post::pluck('slug'),
+  ],
+
+  /*
+    |--------------------------------------------------------------------------
     | Not Found Page
     |--------------------------------------------------------------------------
     |

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -30,11 +30,6 @@ parameters:
 			count: 1
 			path: src/Console/Commands/Build.php
 
-		-
-			message: '#^Parameter \#2 \$contents of static method Illuminate\\Support\\Facades\\File\:\:put\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Console/Commands/Build.php
 		
 		-
 			message: '#^While loop condition is always true\.$#'

--- a/tests/Unit/BuildTest.php
+++ b/tests/Unit/BuildTest.php
@@ -77,4 +77,32 @@ class BuildTest extends TestCase
     File::deleteDirectory($tempInputDir);
     File::deleteDirectory($tempOutputDir);
   }
+
+  public function test_build_site_handles_dynamic_routes(): void
+  {
+    $tempInputDir = base_path('tests/tmp_public');
+    $tempOutputDir = base_path('tests/tmp_output');
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+
+    File::ensureDirectoryExists($tempInputDir);
+
+    Config::set('scabbard.copy_dirs', [$tempInputDir]);
+    Config::set('scabbard.routes', []);
+    Config::set('scabbard.dynamic_routes', [
+      '/posts/{slug}/index.html' => fn () => ['alpha', 'beta'],
+    ]);
+    Config::set('scabbard.output_path', $tempOutputDir);
+
+    app('router')->get('/posts/{slug}', fn ($slug) => view('home'));
+
+    Artisan::call('scabbard:build');
+
+    $this->assertTrue(File::exists("{$tempOutputDir}/posts/alpha/index.html"));
+    $this->assertTrue(File::exists("{$tempOutputDir}/posts/beta/index.html"));
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+  }
 }


### PR DESCRIPTION
## Summary
- add dynamic routes to config
- support dynamic routes in Build command
- document dynamic routes in README
- test dynamic routes
- update phpstan baseline

## Testing
- `composer phpstan`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6878208da1d0832f86e760b3a07bd34f