### PR TITLE
Add output path support for dynamic routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,23 @@ This is a mapping of routes (defined in your app's `routes/web.php`) to their fi
 
 ### Dynamic Routes
 
-Dynamic routes allow generating multiple pages from a single route pattern. Define `dynamic_routes` in your `scabbard.php` config with a mapping of output file patterns to a closure that returns the placeholder values. For example:
+Dynamic routes allow generating multiple pages from a single route pattern.
+Define `dynamic_routes` in your `scabbard.php` config with a mapping of the
+route pattern to an array containing the output path pattern and a callback that
+returns the values for the placeholders. For example:
 
 ```php
 'dynamic_routes' => [
-    '/posts/{slug}/index.html' => fn () => App\Models\Post::pluck('slug'),
+    '/posts/{slug}' => [
+        'output' => '/posts/{slug}/index.html',
+        'values' => fn () => App\Models\Post::pluck('slug'),
+    ],
 ],
 ```
 
-The closure should return an iterable of values. When building, each value replaces the `{slug}` placeholder to produce both the request URI and output file path.
+The callback should return an iterable of values. When building, each value
+replaces the `{slug}` placeholder to produce both the request URI and the output
+file path.
 
 ### Server Port
 

--- a/config/scabbard.php
+++ b/config/scabbard.php
@@ -58,15 +58,18 @@ return [
     | Dynamic Routes
     |--------------------------------------------------------------------------
     |
-    | Mapping of output paths containing placeholders to a closure that returns
-    | the values for those placeholders. The closure should return an iterable
-    | of values. When a single placeholder is used, scalar values are accepted.
-    | For multiple placeholders, return associative arrays keyed by placeholder
-    | name.
+    | Mapping of route patterns containing placeholders to an array with an
+    | `output` path and a `values` callback that returns the values for those
+    | placeholders. The callback should return an iterable. When a single
+    | placeholder is used, scalar values are accepted. For multiple
+    | placeholders, return associative arrays keyed by placeholder name.
     |
     */
   'dynamic_routes' => [
-    // '/posts/{slug}/index.html' => fn () => App\Models\Post::pluck('slug'),
+    // '/posts/{slug}' => [
+    //   'output' => '/posts/{slug}/index.html',
+    //   'values' => fn () => App\Models\Post::pluck('slug'),
+    // ],
   ],
 
   /*

--- a/tests/Unit/BuildTest.php
+++ b/tests/Unit/BuildTest.php
@@ -91,7 +91,10 @@ class BuildTest extends TestCase
     Config::set('scabbard.copy_dirs', [$tempInputDir]);
     Config::set('scabbard.routes', []);
     Config::set('scabbard.dynamic_routes', [
-      '/posts/{slug}/index.html' => fn () => ['alpha', 'beta'],
+      '/posts/{slug}' => [
+        'output' => '/posts/{slug}/index.html',
+        'values' => fn () => ['alpha', 'beta'],
+      ],
     ]);
     Config::set('scabbard.output_path', $tempOutputDir);
 


### PR DESCRIPTION
## Summary
- support mapping dynamic routes to output paths
- document new dynamic route syntax
- update dynamic route example configuration
- test new dynamic route configuration

No AGENTS.md was found in the repository.

## Testing
- `composer phpstan`
- `vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68782b23ed64832f99eb9ade5bac060a