### PR TITLE
Fix dynamic route callback method check

### DIFF
--- a/src/Console/Commands/Build.php
+++ b/src/Console/Commands/Build.php
@@ -204,13 +204,12 @@ class Build extends Command
     }
 
     return function () use ($class, $attribute) {
-      if (method_exists($class, 'pluck')) {
+      if (is_callable([$class, 'pluck'])) {
         return $class::pluck($attribute);
       }
-      else {
-        $this->error($this->timestampPrefix() . "Method `pluck` not found on model {$class}. Check your dynamic routes config.");
-        return [];
-      }
+
+      $this->error($this->timestampPrefix() . "Method `pluck` not found on model {$class}. Check your dynamic routes config.");
+      return [];
     };
   }
 


### PR DESCRIPTION
## Summary
- use `is_callable()` for dynamic route callback detection

## Testing
- `composer phpstan`
- `vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_687a9929cb5c832f9574994936067168