### PR TITLE
Add configurable asset fingerprinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ These are directories that are copied wholesale into your configured output dire
 
 **Default**: `./public`.
 
+### Fingerprint Patterns
+
+Specify which files should be fingerprinted during the build. Patterns use
+shell-style wildcards (e.g., `**/*.css`). Fingerprinted filenames will include a
+hash based on file content and all HTML files will have their references updated
+accordingly.
+Note: only `href` and `src` attributes with quoted values are rewritten. Any query strings or fragments are preserved.
+
+**Default**: `[]` (no fingerprinting).
+
 ### Server Port
 
 The port your server runs on. 

--- a/config/scabbard.php
+++ b/config/scabbard.php
@@ -75,6 +75,19 @@ return [
 
   /*
     |--------------------------------------------------------------------------
+    | Fingerprint Patterns
+    |--------------------------------------------------------------------------
+    |
+    | Array of file patterns that should be fingerprinted. Patterns use shell-
+    | style wildcards (e.g., `**\/*.css`). If empty, no files are fingerprinted.
+    |
+    */
+  'fingerprint' => [
+    // 'assets/**/*.css',
+  ],
+
+  /*
+    |--------------------------------------------------------------------------
     | Not Found Page
     |--------------------------------------------------------------------------
     |

--- a/tests/Unit/BuildTest.php
+++ b/tests/Unit/BuildTest.php
@@ -108,4 +108,135 @@ class BuildTest extends TestCase
     File::deleteDirectory($tempInputDir);
     File::deleteDirectory($tempOutputDir);
   }
+
+  public function test_build_site_fingerprints_files(): void
+  {
+    $tempInputDir = base_path('tests/tmp_public');
+    $tempOutputDir = base_path('tests/tmp_output');
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+
+    File::ensureDirectoryExists($tempInputDir);
+    File::put("{$tempInputDir}/dummy.txt", 'dummy');
+
+    Config::set('scabbard.copy_dirs', [$tempInputDir]);
+    Config::set('scabbard.routes', ['/fp' => 'fp.html']);
+    Config::set('scabbard.output_path', $tempOutputDir);
+    Config::set('scabbard.fingerprint', ['dummy.txt']);
+
+    app('router')->get('/fp', fn () => view('asset'));
+
+    Artisan::call('scabbard:build');
+
+    $files = collect(File::allFiles($tempOutputDir));
+    $fingerprinted = $files->first(function ($file) {
+      return str_starts_with($file->getFilename(), 'dummy.') && $file->getExtension() === 'txt';
+    });
+
+    $this->assertNotNull($fingerprinted);
+    $this->assertFalse(File::exists("{$tempOutputDir}/dummy.txt"));
+
+    $html = File::get("{$tempOutputDir}/fp.html");
+    $this->assertStringContainsString($fingerprinted->getFilename(), $html);
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+  }
+
+  public function test_build_site_fingerprints_nested_files(): void
+  {
+    $tempInputDir = base_path('tests/tmp_public');
+    $tempOutputDir = base_path('tests/tmp_output');
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+
+    File::ensureDirectoryExists("{$tempInputDir}/assets/css", 0755);
+    File::put("{$tempInputDir}/assets/css/nest.css", 'body{}');
+
+    Config::set('scabbard.copy_dirs', [$tempInputDir]);
+    Config::set('scabbard.routes', ['/nested' => 'nested.html']);
+    Config::set('scabbard.output_path', $tempOutputDir);
+    Config::set('scabbard.fingerprint', ['assets/**/*.css']);
+
+    app('router')->get('/nested', fn () => view('nested'));
+
+    Artisan::call('scabbard:build');
+
+    $files = collect(File::allFiles($tempOutputDir));
+    $fingerprinted = $files->first(fn ($file) => str_starts_with($file->getFilename(), 'nest.') && $file->getExtension() === 'css');
+
+    $this->assertNotNull($fingerprinted);
+    $this->assertFalse(File::exists("{$tempOutputDir}/assets/css/nest.css"));
+
+    $html = File::get("{$tempOutputDir}/nested.html");
+    $this->assertStringContainsString($fingerprinted->getFilename(), $html);
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+  }
+
+  public function test_build_site_does_not_fingerprint_when_disabled(): void
+  {
+    $tempInputDir = base_path('tests/tmp_public');
+    $tempOutputDir = base_path('tests/tmp_output');
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+
+    File::ensureDirectoryExists($tempInputDir);
+    File::put("{$tempInputDir}/dummy.txt", 'dummy');
+
+    Config::set('scabbard.copy_dirs', [$tempInputDir]);
+    Config::set('scabbard.routes', ['/plain' => 'plain.html']);
+    Config::set('scabbard.output_path', $tempOutputDir);
+    Config::set('scabbard.fingerprint', []);
+
+    app('router')->get('/plain', fn () => view('asset'));
+
+    Artisan::call('scabbard:build');
+
+    $this->assertTrue(File::exists("{$tempOutputDir}/dummy.txt"));
+
+    $html = File::get("{$tempOutputDir}/plain.html");
+    $this->assertStringContainsString('/dummy.txt', $html);
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+  }
+
+  public function test_build_site_fingerprints_files_with_query_parameters(): void
+  {
+    $tempInputDir = base_path('tests/tmp_public');
+    $tempOutputDir = base_path('tests/tmp_output');
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+
+    File::ensureDirectoryExists($tempInputDir);
+    File::put("{$tempInputDir}/dummy.txt", 'dummy');
+
+    Config::set('scabbard.copy_dirs', [$tempInputDir]);
+    Config::set('scabbard.routes', ['/query' => 'query.html']);
+    Config::set('scabbard.output_path', $tempOutputDir);
+    Config::set('scabbard.fingerprint', ['dummy.txt']);
+
+    app('router')->get('/query', fn () => view('query'));
+
+    Artisan::call('scabbard:build');
+
+    $files = collect(File::allFiles($tempOutputDir));
+    $fingerprinted = $files->first(function ($file) {
+      return str_starts_with($file->getFilename(), 'dummy.') && $file->getExtension() === 'txt';
+    });
+
+    $this->assertNotNull($fingerprinted);
+
+    $html = File::get("{$tempOutputDir}/query.html");
+    $this->assertStringContainsString($fingerprinted->getFilename() . '?v=1', $html);
+
+    File::deleteDirectory($tempInputDir);
+    File::deleteDirectory($tempOutputDir);
+  }
 }

--- a/tests/views/asset.blade.php
+++ b/tests/views/asset.blade.php
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="/dummy.txt">
+Home with asset

--- a/tests/views/nested.blade.php
+++ b/tests/views/nested.blade.php
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="/assets/css/nest.css">
+Nested asset

--- a/tests/views/query.blade.php
+++ b/tests/views/query.blade.php
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="/dummy.txt?v=1">
+Query asset


### PR DESCRIPTION
## Summary
- add fingerprint patterns to config
- document new config option
- fingerprint files after building and rewrite HTML references
- test fingerprinting
- implement robust pattern matching and nested asset tests
- improve fingerprinting replacement logic and add tests for disabled fingerprinting and query strings

No AGENTS.md found in the repo.

## Testing
- `composer phpstan`
- `vendor/bin/phpunit --stop-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688a80af88b8832f952abadf0bcf9d74