### PR TITLE
Fix font fingerprinting in CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ These are directories that are copied wholesale into your configured output dire
 
 Specify which files should be fingerprinted during the build. Patterns use
 shell-style wildcards (e.g., `**/*.css`). Fingerprinted filenames will include a
-hash based on file content and all HTML files will have their references updated
-accordingly.
-Note: only `href` and `src` attributes with quoted values are rewritten. Any query strings or fragments are preserved.
+hash based on file content and all HTML and CSS files will have their references
+updated accordingly.
+Note: only `href` and `src` attributes with quoted values, and `url()` references in CSS are rewritten. Any query strings or fragments are preserved.
 
 **Default**: `[]` (no fingerprinting).
 

--- a/tests/views/font.blade.php
+++ b/tests/views/font.blade.php
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="/assets/css/font.css">
+Font asset


### PR DESCRIPTION
## Summary
- support updating font paths when fingerprinting runs
- cover font fingerprinting with tests
- mention CSS rewriting in README

No `AGENTS.md` found in repo root.

## Testing
- `composer phpstan`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688aa4cfdec0832f938474d143b17f34