### PR TITLE
Switch CSS fingerprinting to parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "illuminate/console": "^10.0 || ^11.0 || ^12.0",
     "illuminate/filesystem": "^10.0 || ^11.0 || ^12.0",
     "illuminate/view": "^10.0 || ^11.0 || ^12.0",
-    "illuminate/support": "^10.0 || ^11.0 || ^12.0"
+    "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+    "sabberworm/php-css-parser": "^9.0"
   },
   "require-dev": {
     "orchestra/testbench": "^8.0 || ^9.0",


### PR DESCRIPTION
## Summary
- add sabberworm/php-css-parser dependency
- refactor Build command to use CSS parser for updating `url()` references

No `AGENTS.md` found in this project.

## Testing
- `vendor/bin/phpunit -c phpunit.xml --stop-on-failure`
- `composer phpstan`

------
https://chatgpt.com/codex/tasks/task_e_688ab3eb5bdc832fa9a263a86638c6b8